### PR TITLE
Potentially fixing the bug of incorrect deep_free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 bin/
+src/deep_main.c
+.vscode/settings.json

--- a/include/deep_mem.h
+++ b/include/deep_mem.h
@@ -12,7 +12,7 @@
 #define P_FLAG_OFFSET (1) /* previous block is allocated */
 #define P_FLAG_MASK (0x00000002)
 #define BLOCK_SIZE_MULTIPLIER (3)
-#define BLOCK_SIZE_MASK (0xfffffff4)
+#define BLOCK_SIZE_MASK (0xfffffffc)
 #define REMAINDER_SIZE_MULTIPLIER BLOCK_SIZE_MULTIPLIER
 #define REMAINDER_SIZE_MASK ((0xffffffff << 32) & BLOCK_SIZE_MASK)
 

--- a/src/deep_main.c
+++ b/src/deep_main.c
@@ -30,6 +30,20 @@ log_memory (void *buff, size_t size)
     }
 }
 
+void cycletest(uint32_t n) {
+  printf("\nTEST ON MALLOCING/FREEING %u bytes: \n\n", n);
+  for(int i = 1; i <= ITER; i++) {
+    uint8_t *p = deep_malloc(n);
+    deep_info("malloc %d times, @%p", i, p);
+    if (p == NULL) {
+      deep_error("malloc fail @%d", i);
+      break;
+    }
+    *p = 0xFF;
+    deep_free(p);
+  }
+}
+
 int main(void) {
     // deep_info("This a log for information");
     // deep_debug("This a log for debuging");
@@ -37,18 +51,8 @@ int main(void) {
     // deep_error("This a log for error");
     // deep_dump("example", example, 100);
     deep_mem_init(deepvm_mempool, DEEPVM_MEMPOOL_SIZE);
-    for(int i = 1; i <= ITER; i++) {
-        uint8_t *p = deep_malloc(100);
-        deep_info("malloc %d times, @%p", i, p);
-        if (i >= 290) {
-            // log_memory(deepvm_mempool, DEEPVM_MEMPOOL_SIZE);
-        }
-        if (p == NULL) {
-            deep_error("malloc fail @%d", i);
-            break;
-        }
-        *p = 0xFF;
-        deep_free(p);
-    }
+    cycletest(100); /* sorted */
+    cycletest(60);  /* sorted on 64bit; fast on 32bit */
+    cycletest(40);  /* fast */
     return 0;
 }

--- a/src/deep_main.c
+++ b/src/deep_main.c
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -8,6 +7,9 @@
 #include "deep_log.h"
 #define WASM_FILE_SIZE 1024
 #define DEEPVM_MEMPOOL_SIZE 30*1024
+
+#define ITER 1000
+
 uint8_t deepvm_mempool[DEEPVM_MEMPOOL_SIZE]= {0};
 uint8_t example[100]= {"This is a example for logsys."};
 
@@ -35,7 +37,7 @@ int main(void) {
     // deep_error("This a log for error");
     // deep_dump("example", example, 100);
     deep_mem_init(deepvm_mempool, DEEPVM_MEMPOOL_SIZE);
-    for(int i = 0; i < 1000; i++) {
+    for(int i = 1; i <= ITER; i++) {
         uint8_t *p = deep_malloc(100);
         deep_info("malloc %d times, @%p", i, p);
         if (i >= 290) {


### PR DESCRIPTION
1. Store the offset between head and payload in a global variable.
2. Use this offset, not sizeof(), to get the right position of head.
3. The bug was originally reproducible on my 64bit mac, now it's fixed.
May require further testing on a 32bit machine as well.
4. Further fix a bug on the inconsistency on block_size that causes
a few bytes not to be freed in every cycle.
5. Known issue: fast_free causes segfault; fast_bins are always NULL.